### PR TITLE
Avoid undefined behaviour when buffer is re-allocated.

### DIFF
--- a/nvfbc/src/system.rs
+++ b/nvfbc/src/system.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
@@ -20,14 +21,24 @@ use crate::{
 };
 
 pub struct SystemCapturer {
+	/// The nvfbc handle.
 	handle: Handle,
-	buffer: *mut c_void,
+
+	/// The pointer to the data buffer.
+	///
+	/// The pointer is stored in a [`Box`] because nvfbc will overwrite it when it re-allocates the buffer.
+	/// If we stored the pointer directly in the struct, then moving the struct would cause nvfbc to write
+	/// to an invalid memory address.
+	///
+	/// Since the writes to the pointer happen without the compiler knowing about it,
+	/// the pointer is also stored in a [`Cell`].
+	buffer: Box<Cell<*mut c_void>>,
 }
 
 impl SystemCapturer {
 	pub fn new() -> Result<Self, Error> {
 		let handle = create_handle()?;
-		let self_ = Self { handle, buffer: null_mut() };
+		let self_ = Self { handle, buffer: Box::new(Cell::new(null_mut())) };
 		Ok(self_)
 	}
 
@@ -41,7 +52,7 @@ impl SystemCapturer {
 		let mut params: nvfbc_sys::NVFBC_TOSYS_SETUP_PARAMS = unsafe { MaybeUninit::zeroed().assume_init() };
 		params.dwVersion = nvfbc_sys::NVFBC_TOSYS_SETUP_PARAMS_VER;
 		params.eBufferFormat = buffer_format as u32;
-		params.ppBuffer = &mut self.buffer;
+		params.ppBuffer = self.buffer.as_ptr();
 		check_ret(self.handle, unsafe { nvfbc_sys::NvFBCToSysSetUp(self.handle, &mut params) })
 	}
 
@@ -56,7 +67,8 @@ impl SystemCapturer {
 		params.dwFlags = nvfbc_sys::NVFBC_TOSYS_GRAB_FLAGS_NVFBC_TOSYS_GRAB_FLAGS_NOFLAGS;
 		params.pFrameGrabInfo = &mut frame_info;
 		check_ret(self.handle, unsafe { nvfbc_sys::NvFBCToSysGrabFrame(self.handle, &mut params) })?;
-		let buffer = unsafe { std::slice::from_raw_parts(self.buffer.cast(), frame_info.dwByteSize as usize) };
+		let buffer_ptr = unsafe { self.buffer.as_ptr().read_volatile().cast() };
+		let buffer = unsafe { std::slice::from_raw_parts(buffer_ptr, frame_info.dwByteSize as usize) };
 
 		Ok(SystemFrameInfo {
 			buffer,


### PR DESCRIPTION
Since nvfbc will overwrite the pointer when it re-allocates the system buffer, we can never move the pointer.

This PR ensures that the pointer is never moved, and it also puts it in a cell since it can be written to without the compilers knowledge.